### PR TITLE
Adjusted the supplier guide text

### DIFF
--- a/_includes/howtoapply.html
+++ b/_includes/howtoapply.html
@@ -1,7 +1,7 @@
 <!-- Can we make the how to apply section background and text a different colour? -->
 <div class = "row">
-    <div class="col-md-12">
-       <h2>{{ site.data.i18n.general.apply.title[page.lang] }}</h2>
+    <div class="col-md-12" style="background-color: #F5F5F5; color: black; font:17px; border:solid; border-color:#DDDDDD; border-radius: 10px; border-width: thin; padding: 20px 10px">
+       <h2 >{{ site.data.i18n.general.apply.title[page.lang] }}</h2>
        <p>{{ site.data.i18n.general.apply.description[page.lang] }}</p>
         <p>{{ site.data.i18n.general.apply.link[page.lang] }}</p>
     </div>

--- a/_includes/howtoapply.html
+++ b/_includes/howtoapply.html
@@ -1,7 +1,7 @@
 <!-- Can we make the how to apply section background and text a different colour? -->
 <div class = "row">
-    <div class="col-md-12" style="background-color: #F5F5F5; color: black; font:17px; border:solid; border-color:#DDDDDD; border-radius: 10px; border-width: thin; padding: 20px 10px">
-       <h2 >{{ site.data.i18n.general.apply.title[page.lang] }}</h2>
+    <div class="col-md-12 well well-lg">
+       <h2>{{ site.data.i18n.general.apply.title[page.lang] }}</h2>
        <p>{{ site.data.i18n.general.apply.description[page.lang] }}</p>
         <p>{{ site.data.i18n.general.apply.link[page.lang] }}</p>
     </div>

--- a/_pages/en/index.md
+++ b/_pages/en/index.md
@@ -8,13 +8,13 @@ permalink: /en/index.html
 # Welcome to the Micro-Acquisition website
 
 <div class="row">
-  <div class="col-sm-6">
-    <p class="well ">Are you a <strong>developer / programmer</strong> and you would like to earn some money working on short government contracts?</p>
+  <div class="col-sm-6 well">
+    <p>Are you a <strong>developer / programmer</strong> and you would like to earn some money working on short government contracts?</p>
     <p>Check out the <a href="{{ site.baseurl }}{% link _pages/en/opportunities.md %}" title="Opportunities">Opportunities</a> to see if there are any open opportunities that meet your skills.</p>
     <p>More information about how Micro-Acquisition works can be found in the <a href="{{ site.baseurl }}{% link _pages/en/supplier-guide.md %}" title="Supplier User Guide">Supplier User Guide</a></p>
   </div>
-  <div class="col-sm-6">
-    <p class="well">Are you an <strong>Employment and Social Development Canada employee</strong> who has work packages that could be done by external developers?</p>
+  <div class="col-sm-6 well">
+    <p>Are you an <strong>Employment and Social Development Canada employee</strong> who has work packages that could be done by external developers?</p>
     <p>Send us an email (add link) and we can help you get the process started.</p>
     <p>Information about what you'll need to do can be found in the <a href="{{ site.baseurl }}{% link _pages/en/client-guide.md %}" title="Client User Guide">Client User Guide</a></p>
   </div>

--- a/_pages/en/index.md
+++ b/_pages/en/index.md
@@ -9,12 +9,12 @@ permalink: /en/index.html
 
 <div class="row">
   <div class="col-sm-6">
-    <p style="background-color:#F5F5F5">Are you a <strong>developer / programmer</strong> and you would like to earn some money working on short government contracts?</p>
+    <p class="well ">Are you a <strong>developer / programmer</strong> and you would like to earn some money working on short government contracts?</p>
     <p>Check out the <a href="{{ site.baseurl }}{% link _pages/en/opportunities.md %}" title="Opportunities">Opportunities</a> to see if there are any open opportunities that meet your skills.</p>
     <p>More information about how Micro-Acquisition works can be found in the <a href="{{ site.baseurl }}{% link _pages/en/supplier-guide.md %}" title="Supplier User Guide">Supplier User Guide</a></p>
   </div>
   <div class="col-sm-6">
-    <p style="background-color:#F5F5F5">Are you an <strong>Employment and Social Development Canada employee</strong> who has work packages that could be done by external developers?</p>
+    <p class="well">Are you an <strong>Employment and Social Development Canada employee</strong> who has work packages that could be done by external developers?</p>
     <p>Send us an email (add link) and we can help you get the process started.</p>
     <p>Information about what you'll need to do can be found in the <a href="{{ site.baseurl }}{% link _pages/en/client-guide.md %}" title="Client User Guide">Client User Guide</a></p>
   </div>

--- a/_pages/en/index.md
+++ b/_pages/en/index.md
@@ -9,12 +9,12 @@ permalink: /en/index.html
 
 <div class="row">
   <div class="col-sm-6">
-    <p>Are you a <strong>developer / programmer</strong> and you would like to earn some money working on short government contracts?</p>
+    <p style="background-color:#F5F5F5">Are you a <strong>developer / programmer</strong> and you would like to earn some money working on short government contracts?</p>
     <p>Check out the <a href="{{ site.baseurl }}{% link _pages/en/opportunities.md %}" title="Opportunities">Opportunities</a> to see if there are any open opportunities that meet your skills.</p>
     <p>More information about how Micro-Acquisition works can be found in the <a href="{{ site.baseurl }}{% link _pages/en/supplier-guide.md %}" title="Supplier User Guide">Supplier User Guide</a></p>
   </div>
   <div class="col-sm-6">
-    <p>Are you an <strong>Employment and Social Development Canada employee</strong> who has work packages that could be done by external developers?</p>
+    <p style="background-color:#F5F5F5">Are you an <strong>Employment and Social Development Canada employee</strong> who has work packages that could be done by external developers?</p>
     <p>Send us an email (add link) and we can help you get the process started.</p>
     <p>Information about what you'll need to do can be found in the <a href="{{ site.baseurl }}{% link _pages/en/client-guide.md %}" title="Client User Guide">Client User Guide</a></p>
   </div>

--- a/_pages/en/supplier-guide.md
+++ b/_pages/en/supplier-guide.md
@@ -41,11 +41,8 @@ Before sending your email, verify that you have included the following in your e
 - The name of the opportunity you are applying for
 - Your name
 - Your business name (if different from your name)
-- Written affirmations as follows:
-  - "I can complete the work by *add completion date from the opportunity statement*"
-  - "I agree to be paid by credit card or PayPal"
-  - "I have the skills required to complete the work described in the *add name of the opportunity* opportunity statement
-- A text description of your experience with the required skills (500 words or less)
+- Written affirmation that by applying to an opportunity, you agree to complete the work by the completion date in the opportunity statement and that you agree to be paid by credit card or PayPal
+- Responses to all of the Evaluation Criteria for the opportunity you are applying for with the required skills (500 words or less)
 Note that these requirements are marked as a pass/fail.
 You will not be graded on each but a pass is required for each item in order to be able to be considered for an opportunity
 


### PR DESCRIPTION
closing issue #42 

Changes made as follows:
In the Ready to Apply section:

Removed the 3 written affirmation bullets and replace with text that says 'by applying to an opportunity, you agree that you can complete the work by the completion date in the opportunity statement and that you agree to be paid by credit card or PayPal.
Removed the bullet that starts with 'a text description of your experience' and replace with 'responses to all of the Evaluation Criteria for the opportunity you are applying for