### PR TITLE
Adjusted  the supplier guide text

### DIFF
--- a/_pages/en/supplier-guide.md
+++ b/_pages/en/supplier-guide.md
@@ -41,13 +41,11 @@ Before sending your email, verify that you have included the following in your e
 - The name of the opportunity you are applying for
 - Your name
 - Your business name (if different from your name)
-- Written affirmations as follows:
-  - "I can complete the work by *add completion date from the opportunity statement*"
-  - "I agree to be paid by credit card or PayPal"
-  - "I have the skills required to complete the work described in the *add name of the opportunity* opportunity statement
-- A text description of your experience with the required skills (500 words or less)
+- Written affirmation that by applying to an opportunity, you agree to complete the work by the completion date in the opportunity statement and that you agree to be paid by credit card or PayPal
+- Responses to all of the Evaluation Criteria for the opportunity you are applying for with the required skills (500 words or less).
+
 Note that these requirements are marked as a pass/fail.
-You will not be graded on each but a pass is required for each item in order to be able to be considered for an opportunity
+You will not be graded on each but a pass is required for each item in order to be able to be considered for an opportunity.
 
 ## After applying
 

--- a/_pages/en/supplier-guide.md
+++ b/_pages/en/supplier-guide.md
@@ -41,11 +41,15 @@ Before sending your email, verify that you have included the following in your e
 - The name of the opportunity you are applying for
 - Your name
 - Your business name (if different from your name)
-- Written affirmation that by applying to an opportunity, you agree to complete the work by the completion date in the opportunity statement and that you agree to be paid by credit card or PayPal
-- Responses to all of the Evaluation Criteria for the opportunity you are applying for with the required skills (500 words or less).
+- Responses to all of the Evaluation Criteria for the opportunity you are applying for
 
 Note that these requirements are marked as a pass/fail.
 You will not be graded on each but a pass is required for each item in order to be able to be considered for an opportunity.
+
+<div class="well">By applying to an opportunity, you agree to:
+
+<ul><li>complete the work by the completion date in the opportunity statement and</li>
+<li>be paid by credit card or PayPal </li></ul></div>
 
 ## After applying
 


### PR DESCRIPTION
Removed the 3 written affirmation bullets and replace with text that says 'by applying to an opportunity, you agree that you can complete the work by the completion date in the opportunity statement and that you agree to be paid by credit card or PayPal.
Removed the bullet that starts with 'a text description of your experience' and replace with 'responses to all of the Evaluation Criteria for the opportunity you are applying for