### PR TITLE
Adjusted text on some pages

### DIFF
--- a/_pages/en/index.md
+++ b/_pages/en/index.md
@@ -42,7 +42,7 @@ On this web site you will find opportunities to be paid for coding work which me
 
 ## Gratitude
 
-This pilot would not have been possible without the help of the kind folks at the [BC Developers Exchange](https://bcdevexchange.org/)/[BC Digital Marketplace](https://digital.gov.bc.ca/marketplace) who have lead the way for years, and from the wonderful people at the Office of Small and Medium Enterprises who have generously shared their expertise.
+This pilot would not have been possible without the help of the kind folks at the [BC Developers Exchange](https://bcdevexchange.org/)/[BC Digital Marketplace](https://digital.gov.bc.ca/marketplace) who have lead the way for years, and from the wonderful people at the [Office of Small and Medium Enterprises](https://www.tpsgc-pwgsc.gc.ca/app-acq/pme-sme/index-eng.html) who have generously shared their expertise.
 We have also endeavoured to learn from the lessons of the [GC Developers Exchange](https://github.com/canada-ca/devex) (the Government of Canada's first foray into low dollar value acquisitions for open source code).
 
 ## Feedback

--- a/_pages/en/index.md
+++ b/_pages/en/index.md
@@ -48,6 +48,6 @@ We have also endeavoured to learn from the lessons of the [GC Developers Exchang
 ## Feedback
 
 We want to hear from you!
-If you are having trouble using this website, if you have questions if you are finding any of our processes confusing.
+If you are having trouble using this website, if you have questions, if you are finding any of our processes confusing.
 Let us know!
-Open an issue on the Micro-Acquisition repo *add link* or send us an email *add link*.
+Open an issue on the [Micro-Acquisition repo](https://github.com/canada-ca/micro-acquisition) or send us an email *add link*.

--- a/_pages/en/supplier-guide.md
+++ b/_pages/en/supplier-guide.md
@@ -42,6 +42,9 @@ Before sending your email, verify that you have included the following in your e
 - Your name
 - Your business name (if different from your name)
 - Responses to all of the Evaluation Criteria for the opportunity you are applying for
+- "I affirm that *(fill in the blank with either*: 
+1. I am Canadian and/or First Nations, Métis, Inuit or 
+2. I have all the relevant work permits to work in Canada")
 
 Note that these requirements are marked as a pass/fail.
 You will not be graded on each but a pass is required for each item in order to be able to be considered for an opportunity.
@@ -54,7 +57,7 @@ You will not be graded on each but a pass is required for each item in order to 
 ## After applying
 
 Once the opportunity deadline has passed, the applications will be evaluated.
-If multiple suppliers pass the evaluation, those suppliers will be assigned a number.
+If multiple suppliers pass the evaluation criteria, those suppliers will be assigned a number.
 A random number generator will then be used to select the winning supplier.
 
 You will be advised via email if you have (or have not) been selected.

--- a/_pages/en/supplier-guide.md
+++ b/_pages/en/supplier-guide.md
@@ -45,8 +45,8 @@ Before sending your email, verify that you have included the following in your e
 - Your name
 - Your business name (if different from your name)
 - Responses to all of the Evaluation Criteria for the opportunity you are applying for
-- "I affirm that *(fill in the blank with either*: 
-1. I am Canadian and/or First Nations, Métis, Inuit or 
+- "I affirm that *(fill in the blank with either*:
+1. I am Canadian and/or First Nations, Métis, Inuit or
 2. I have all the relevant work permits to work in Canada")
 
 Note that these requirements are marked as a pass/fail.

--- a/_pages/en/supplier-guide.md
+++ b/_pages/en/supplier-guide.md
@@ -7,7 +7,8 @@ permalink: /en/supplier-guide.html
 # Supplier user guide
 
 ## Are you Eligible?
-To be eligible to apply to an opportunity on this site you must be Canadian and/or First Nations, Métis, Inuit or you must have the appropriate [work permits](https://www.canada.ca/en/immigration-refugees-citizenship/services/work-canada/permit.html) to work in Canada.
+
+You are eligible for opportunities on this site if you are Canadian and/or First Nations, Métis, Inuit or if you have the appropriate [work permits](https://www.canada.ca/en/immigration-refugees-citizenship/services/work-canada/permit.html) to work in Canada.
 
 ## Before you apply, do you have
 
@@ -22,9 +23,9 @@ If you have not used Git before or need a refresher, this [Git cheat sheet](http
 
 ### 3. The ability to accept payment from a credit card using a payment system or via PayPal
 
-If you have never accepted payment via a credit card or via PayPal, learn about how to get set up to:
+If you have never accepted payment via a credit card or via PayPal, learn about how to get set up to either:
 
-- accept credit cards using a payment system *add a link to some info about this - is there an open source option?* or
+- accept credit cards using a payment system *add a link to some info about this - is there an open source option?*
 - accept payment via PayPal [get set up to accept payment via PayPal](https://www.paypal.com/ca/business/get-paid?kid=p42863580764&gclid=Cj0KCQiAyoeCBhCTARIsAOfpKxhGE1kaeCjl6C4w_xMLIHHGw-EWc9FgPpFUvZXgjFzH81ptH4MTBEgaAoYHEALw_wcB&gclsrc=aw.ds).
 
 Note that simply having a credit card does not mean you are able to accept payment by credit card.
@@ -39,15 +40,16 @@ If you have a question about an opportunity, get them in as fast as possible, an
 ## Ready to apply?
 
 You apply to Micro-Acquisition opportunities by email to this address *add email address*.
-Before sending your email, verify that you have included the following in your email:
+Please include the following information in your email:
 
 - The name of the opportunity you are applying for
 - Your name
 - Your business name (if different from your name)
 - Responses to all of the Evaluation Criteria for the opportunity you are applying for
-- "I affirm that *(fill in the blank with either*:
-1. I am Canadian and/or First Nations, Métis, Inuit or
-2. I have all the relevant work permits to work in Canada")
+- One of the following written statements:
+
+  1. I affirm that I am Canadian and/or First Nations, Métis, Inuit or
+  2. I affirm that I have all the relevant work permits to work in Canada
 
 Note that these requirements are marked as a pass/fail.
 You will not be graded on each but a pass is required for each item in order to be able to be considered for an opportunity.

--- a/_pages/en/supplier-guide.md
+++ b/_pages/en/supplier-guide.md
@@ -6,6 +6,9 @@ permalink: /en/supplier-guide.html
 ---
 # Supplier user guide
 
+## Are you Eligible?
+To be eligible to apply to an opportunity on this site you must be Canadian and/or First Nations, Métis, Inuit or you must have the appropriate [work permits](https://www.canada.ca/en/immigration-refugees-citizenship/services/work-canada/permit.html) to work in Canada.
+
 ## Before you apply, do you have
 
 ### 1. An account on an public source code repository


### PR DESCRIPTION
1. Added the following as a bullet to the 'Ready to Apply?' section "the following text "I affirm that <fill in the blank with either: 1. I am Canadian and/or First Nations, Métis, Inuit or 2. I have all the relevant work permits to work in Canada>
In the 'After applying' section replaced this text: "If multiple suppliers pass the evaluation" with "If multiple suppliers pass the evaluation criteria"
closing issue #54

2. Added an 'are you eligible' section to the top of the Supplier User Guide page 
closing issue #53 

3. Added a link to OSME's website on the index page 
closing issue #51 

4. Added a link to the micro-acquisition repo in the feedback section of the index page 
closing issue #52 

@RachelMuston please check if they are all in the right place?