### PR TITLE
Full width panel on home page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,3 @@
-</main>
-
 <div class="container mrgn-tp-xl mrgn-bttm-xl">
   <div class="pageDetails">
     <div class="row">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -51,5 +51,3 @@
 
   {% include breadcrumbs.html %}
 </header>
-
-<main property="mainContentOfPage" class="container">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,8 +4,11 @@
 {% include head.html %}
 <body vocab="http://schema.org/" typeof="WebPage" class="page-{{ page.ref }}">
 {% include header.html %}
-{{ content }}
+<main property="mainContentOfPage" class="landingpage">
+    {%- if page.ref != "home" -%}<div class="container">{%- endif -%}
+    {{ content }}
+    {%- if page.ref != "home" -%}</div>{%- endif -%}
+</main>
 {% include footer.html %}
 </body>
-
 </html>

--- a/_pages/en/index.md
+++ b/_pages/en/index.md
@@ -5,46 +5,51 @@ lang: en
 permalink: /en/index.html
 ---
 <!-- markdownlint-disable MD041 -->
-<section class="well well-sm brdr-0">
+<section class="stretch-panel" style="width: 100%; background-color: #EDEDED; padding: 30px 0;">
     <div class="container">
         <div class="row wb-eqht mrgn-tp-md mrgn-bttm-md">
             <div class="col-md-8 col-lrg-8">
-<h1 class="provisional gc-thickline mrgn-tp-0 mrgn-bttm-lg" style="font-size: 60px"> Calling all coders!</h1>
-
-<p>Employment and Social Development Canada (ESDC) is looking for coders that can create and deliver custom code under an open source license.</p>
-
-<p>These work opportunities are low dollar value ($10K or less) and involve the use of <a href="https://www.tpsgc-pwgsc.gc.ca/esc-src/protection-safeguarding/niveaux-levels-eng.html" target="_blank">unclassified, non-protected information</a> only (so security clearance is not required).</p>
-
-<p>Contribute to increased working in the open and reuse of code in the Government of Canada!</p>
-<br>
-<p><a href="{{ site.baseurl }}{% link _pages/en/opportunities.md %}" title="Opportunities"><button type="button" class="btn btn-primary btn-lrg">View opportunities &nbsp; <span class="glyphicon glyphicon-arrow-right" aria-hidden="true"></span></button></a></p>
-</div>
-<div class="col-md-4 col-lrg-4">
-<img src="/assets/images/computer.png" alt="Computer with code">
+                <h1 class="provisional gc-thickline mrgn-tp-0 mrgn-bttm-lg" style="font-size: 60px"> Calling all coders!</h1>
+                <p>Employment and Social Development Canada (ESDC) is looking for coders that can create and deliver custom code under an open source license.</p>
+                <p>These work opportunities are low dollar value ($10K or less) and involve the use of <a href="https://www.tpsgc-pwgsc.gc.ca/esc-src/protection-safeguarding/niveaux-levels-eng.html" target="_blank">unclassified, non-protected information</a> only (so security clearance is not required).</p>
+                <p>Contribute to increased working in the open and reuse of code in the Government of Canada!</p>
+                <br>
+                <p><a href="{{ site.baseurl }}{% link _pages/en/opportunities.md %}" title="Opportunities">
+                    <button type="button" class="btn btn-primary btn-lrg">View opportunities &nbsp; <span class="glyphicon glyphicon-arrow-right" aria-hidden="true"></span></button>
+                </a></p>
+            </div>
+            <div class="col-md-4 col-lrg-4">
+                <img src="/assets/images/computer.png" alt="Computer with code">
             </div>
         </div>
     </div>
 </section>
 
-<h2>How is this different from other Government of Canada procurement  opportunities?</h2>
-<p>Our goal is to make the process simpler for you from start to finish by:</p>
-<ul style="list-style: none;  text-indent: -45px; margin-left:100px;">
-<li> <span class="glyphicon glyphicon-send" style="font-size: 2em; margin: 0 4rem 1rem 0;"> </span><strong> Easier application process.</strong> Complete and submit your application in 2 hours or less.</li>
-<p></p>
-<li><span class="glyphicon glyphicon-repeat" style="font-size: 2em; margin: 0 4rem 1rem 0;"> </span> <strong> Quick selection turnaround.</strong> The evaluation of applications for an opportunity is fast and light-touch. We anticipate announcing the winning supplier two business days following the closing of an opportunity.</li>
-<p></p>
-<li><span class="glyphicon glyphicon-ok" style="font-size: 2em; margin: 0 4rem 1rem 0"> </span> <strong> Fewer hurdles to winning opportunities.</strong> No lengthy pre-approval processes, anonymized evaluation process to reduce bias and all work is done virtually so an NCR location is not required. </li>
-<p></p>
-<li><span class="glyphicon glyphicon-usd" style="font-size: 2em;  margin: 0 4rem 1rem 0"> </span> <strong>Faster payment.</strong> Deliver your code and receive your payment by credit card or PayPal.</li>
-</ul>
-<br>
-<p> Learn more about the process in the <a href="{{ site.baseurl }}{% link _pages/en/user-guide.md %}" title="User Guide">User Guide</a></p>
-
-## About this pilot
-
-<p>This micro-acquisition pilot project is being run for one year at <a href="https://www.canada.ca/en/employment-social-development.html" target="_blank">Employment and Social Development Canada</a> through a partnership between the Innovation Information Technology Branch and the Chief Financial Officer Branch.</p>
-
-<p>This pilot would not have been possible without the help of the <a href="https://bcdevexchange.org/" target="_blank">BC Developers Exchange</a>/<a href="https://digital.gov.bc.ca/marketplace" target="_blank">BC Digital Marketplace</a> who have lead the way for years, and from the <a href="https://www.tpsgc-pwgsc.gc.ca/app-acq/pme-sme/index-eng.html" target="_blank">Office of Small and Medium Enterprises</a> who have generously shared their expertise.
-We have also endeavoured to learn from the lessons of the <a href="https://github.com/canada-ca/devex" target="_blank">GC Developers Exchange</a> (the Government of Canada's first foray into low dollar value procurement of open source code).</p>
-
-<p><a href="mailto:microacquisition@hrsdc-rhdcc.gc.ca">Contact us</a> if you are an ESDC team with a coding opportunity!</p>
+<div class="container">
+    <h2>How is this different from other Government of Canada procurement  opportunities?</h2>
+    <p>Our goal is to make the process simpler for you from start to finish by:</p>
+    <ul style="list-style: none; text-indent: -45px; margin-left:100px;">
+        <li>
+            <span class="glyphicon glyphicon-send" style="font-size: 2em; margin: 0 4rem 1rem 0;"></span>
+            <strong>Easier application process.</strong> Complete and submit your application in 2 hours or less.
+        </li>
+        <li>
+            <span class="glyphicon glyphicon-repeat" style="font-size: 2em; margin: 0 4rem 1rem 0;"></span>
+            <strong> Quick selection turnaround.</strong> The evaluation of applications for an opportunity is fast and light-touch. We anticipate announcing the winning supplier two business days following the closing of an opportunity.</li>
+        <li>
+            <span class="glyphicon glyphicon-ok" style="font-size: 2em; margin: 0 4rem 1rem 0"></span>
+            <strong> Fewer hurdles to winning opportunities.</strong> No lengthy pre-approval processes, anonymized evaluation process to reduce bias and all work is done virtually so an NCR location is not required.
+        </li>
+        <li>
+            <span class="glyphicon glyphicon-usd" style="font-size: 2em;  margin: 0 4rem 1rem 0"></span>
+            <strong>Faster payment.</strong> Deliver your code and receive your payment by credit card or PayPal.
+        </li>
+    </ul>
+    <br>
+    <p>Learn more about the process in the <a href="{{ site.baseurl }}{% link _pages/en/user-guide.md %}" title="User Guide">User Guide</a></p>
+    <h2>About this pilot</h2>
+    <p>This micro-acquisition pilot project is being run for one year at <a href="https://www.canada.ca/en/employment-social-development.html" target="_blank">Employment and Social Development Canada</a> through a partnership between the Innovation Information Technology Branch and the Chief Financial Officer Branch.</p>
+    <p>This pilot would not have been possible without the help of the <a href="https://bcdevexchange.org/" target="_blank">BC Developers Exchange</a>/<a href="https://digital.gov.bc.ca/marketplace" target="_blank">BC Digital Marketplace</a> who have lead the way for years, and from the <a href="https://www.tpsgc-pwgsc.gc.ca/app-acq/pme-sme/index-eng.html" target="_blank">Office of Small and Medium Enterprises</a> who have generously shared their expertise.</p>
+    <p>We have also endeavoured to learn from the lessons of the <a href="https://github.com/canada-ca/devex" target="_blank">GC Developers Exchange</a> (the Government of Canada's first foray into low dollar value procurement of open source code).</p>
+    <p><a href="mailto:microacquisition@hrsdc-rhdcc.gc.ca">Contact us</a> if you are an ESDC team with a coding opportunity!</p>
+</div>


### PR DESCRIPTION
Fixes #111

To make the section full width, the container class had to be removed from the `main` element.
Moved the `main` to the default layout.
Add a `div` with `class="container"` for all pages except the home page. (this is so we don't have to fix all the other pages individually)