### PR TITLE
remove how to apply footer from closed opportunities

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -26,8 +26,11 @@
         <p><b>{{ site.data.i18n.general.opportunities.skills[page.lang] }}:</b>{{ page.skills }}</p>
 
         {{ content }}
+       
+        {%- if closeXML > nowXML -%}
+            {% include howtoapply.html %}
+        {%- endif -%}
 
-        {% include howtoapply.html %}
 
         <i>{{ site.data.i18n.general.opportunities.last_modified[page.lang] }} {{ page.last_modified }}</i>
     </div>


### PR DESCRIPTION
This PR removes the 'how to apply' footer from opportunities with a status of 'closed' (since suppliers can no longer apply to these opportunities).