### PR TITLE
Set custom css for empty class

### DIFF
--- a/assets/css/gridify.css
+++ b/assets/css/gridify.css
@@ -11,6 +11,10 @@
   padding-bottom:30px;
 }
 
+.tbl-gridify>tbody>tr[class=""] {
+    background: none !important;
+}
+
 .tbl-gridify td:first-child {
   padding-top:15px;
   background:#777;


### PR DESCRIPTION
When looking at the way datatables generates the html with an empty table, the <tr> element class is empty. 
```html
<tr class="" style="vertical-align: top; min-height: 64px;">
  <td valign="top" colspan="5" class="dataTables_empty">No open opportunities</td>
</tr>
```

On the other end, when the table has data, the classes `col-xs-12 col-md-6` are applied.

So in the custom CSS, we can choose the nameless class and remove the background just for those ones:

```css
.tbl-gridify>tbody>tr[class=""] {
    background: none !important;
}
```