### PR TITLE
Add email to security disclosure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,10 @@
 
 # Security
 
-**Do not post any security issues on the public repository!** Security vulnerabilities must be reported by email to ...
+**Do not post any security issues on the public repository!** Security vulnerabilities must be reported by email to the [Micro-Acquisition Pilot Project Team](mailto:"microacquisition@hrsdc-rhdcc.gc.ca")
 
 ______________________
 
 ## Sécurité
 
-**Ne publiez aucun problème de sécurité sur le dépôt publique!** Les vulnérabilités de sécurité doivent être signalées par courriel à ...
+**Ne publiez aucun problème de sécurité sur le dépôt publique!** Les vulnérabilités de sécurité doivent être signalées par courriel à [l'équipe du projet pilote de Micro-Acquisition](mailto:"microacquisition@hrsdc-rhdcc.gc.ca")


### PR DESCRIPTION
The SECURITY.md file did not have an email to report vulnerabilities to. I added the MA pilot email address.