### PR TITLE
New privacy notices

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -9,6 +9,12 @@
       {%- if page.ref == "terms" -%}
       <li><a href="{{ site.baseurl }}{%- if page.lang == 'fr' -%}{% link _pages/fr/guide-utilisateur.md %}{%- else -%}{% link _pages/en/user-guide.md %}{%- endif -%}">{{ site.data.i18n.general.apply.guide[page.lang] }}</a></li>
       {%- endif -%}
+      {%- if page.ref == "survey" -%}
+      <li><a href="{{ site.baseurl }}{%- if page.lang == 'fr' -%}{% link _pages/fr/confidentialite.md %}{%- else -%}{% link _pages/en/privacy.md %}{%- endif -%}">{{ site.data.i18n.general.footer.Nav.Privacy[page.lang].title }}</a></li>
+      {%- endif -%}
+      {%- if page.ref == "contracting" -%}
+      <li><a href="{{ site.baseurl }}{%- if page.lang == 'fr' -%}{% link _pages/fr/confidentialite.md %}{%- else -%}{% link _pages/en/privacy.md %}{%- endif -%}">{{ site.data.i18n.general.footer.Nav.Privacy[page.lang].title }}</a></li>
+      {%- endif -%}
     </ol>
   </div>
 </nav>

--- a/_pages/en/privacy-contracting.md
+++ b/_pages/en/privacy-contracting.md
@@ -1,0 +1,28 @@
+---
+layout: default
+ref: contracting
+lang: en
+permalink: /en/privacy-contracting.html
+---
+
+# Privacy Notice Statement for the Micro-Acquisition contracting process
+
+The information you provide is collected under the authority of the [Financial Administration Act (FAA)](https://laws-lois.justice.gc.ca/eng/acts/f-11/) to assess your skills as part of the application screening process as well as to initiate payment to suppliers who are chosen to work on Micro-Acquisition opportunities.  
+
+Participation in Micro-acquisition pilot (including applying to opportunities, completing and submitting work for micro-acquisition opportunities, and accepting payment) is voluntary. Refusal to provide personal information required as part of the application evaluation purposes will result in you being screened out of opportunities.
+
+Note: Employment and Social Development Canada (ESDC) uses GC Forms to collect application information. GC Forms is a product developed and managed by the Canadian Digital Service at the Treasury Board of Canada Secretariat.
+Learn more about [GC Forms privacy policy](https://digital.canada.ca/legal/privacy/).
+
+The information you provide may be used and/or disclosed for policy analysis, research and/or evaluation purposes.
+However, these additional uses and/or disclosures of your personal information will never result in an administrative decision being made about you.  
+
+The name of the winning supplier for each micro-acquisition opportunity may be published as part of procurement process.
+
+Your personal information is administered in accordance with the *Financial Administration Act*, the *Department of Employment and Social Development Act*, the *Privacy Act* and other applicable laws.
+You have the right to the protection of, access to, and correction of your personal information, which is described in Personal Information Bank(s) [Professional Services Contracts](https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings/standard-personal-information-banks.html#psu912) (PSU 912).
+Instructions for obtaining this information is outlined in the following government publication entitled [Information about programs and information holdings](https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings.html).
+
+Information about programs and information holdings may also be accessed on-line at any Service Canada Centre.
+
+You have the right to file a complaint with the Privacy Commissioner of Canada regarding the institution’s handling of your personal information at: [https://www.priv.gc.ca/faqs/index_e.asp#q005](https://www.priv.gc.ca/faqs/index_e.asp#q005).

--- a/_pages/en/privacy-contracting.md
+++ b/_pages/en/privacy-contracting.md
@@ -11,7 +11,7 @@ The information you provide is collected under the authority of the [Financial A
 
 Participation in Micro-acquisition pilot (including applying to opportunities, completing and submitting work for micro-acquisition opportunities, and accepting payment) is voluntary. Refusal to provide personal information required as part of the application evaluation purposes will result in you being screened out of opportunities.
 
-Note: Employment and Social Development Canada (ESDC) uses GC Forms to collect application information. GC Forms is a product developed and managed by the Canadian Digital Service at the Treasury Board of Canada Secretariat.
+Note: The Micro-Acquisition pilot at Employment and Social Development Canada (ESDC) uses GC Forms to collect application information. GC Forms is a product developed and managed by the Canadian Digital Service at the Treasury Board of Canada Secretariat.
 Learn more about [GC Forms privacy policy](https://digital.canada.ca/legal/privacy/).
 
 The information you provide may be used and/or disclosed for policy analysis, research and/or evaluation purposes.

--- a/_pages/en/privacy-survey.md
+++ b/_pages/en/privacy-survey.md
@@ -1,0 +1,23 @@
+---
+layout: default
+ref: survey
+lang: en
+permalink: /en/privacy-survey.html
+---
+# Privacy Notice Statement for the survey to Micro-Acquisition suppliers
+
+The information you provide is collected under the authority of the [Department of Employment and Social Development Act (DESDA)](https://laws-lois.justice.gc.ca/eng/acts/h-5.7/page-1.html) to evaluate the success of the Micro-Acquisition Pilot including but not limited to, assessing demand for this procurement option and achieving the goal of increased participation of suppliers who would not normally bid on Government of Canada contracts.
+
+Participation in this survey for Micro-Acquisition suppliers is voluntary.
+Refusal to provide personal information will have no consequences.
+
+The information you provide may be used and/or disclosed for policy analysis, research and/or evaluation purposes.  
+However, these additional uses and/or disclosures of your personal information will never result in an administrative decision being made about you.
+
+Your personal information is administered in accordance with the Department of Employment and Social Development Act, the Privacy Act and other applicable laws.
+You have the right to the protection of, access to, and correction of your personal information, which is described in Personal Information Bank [Outreach Activities](https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings/standard-personal-information-banks.html#psu938)(PSU 938).
+Instructions for obtaining this information is outlined in the following government publication entitled [Information about programs and information holdings](https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings.html).
+
+Information about programs and information holdings may also be accessed on-line at any Service Canada Centre.
+
+You have the right to file a complaint with the Privacy Commissioner of Canada regarding the institution’s handling of your personal information at: [https://www.priv.gc.ca/faqs/index_e.asp#q005](https://www.priv.gc.ca/faqs/index_e.asp#q005).

--- a/_pages/en/privacy.md
+++ b/_pages/en/privacy.md
@@ -19,7 +19,7 @@ Participation in the Micro-Acquisition Pilot is voluntary. Refusal to provide pe
 The information you provide by way of feedback, questions, or by requesting to be added to the mailing list, may be used and/or disclosed for policy analysis, research and/or evaluation purposes.
 However, these additional uses and/or disclosures of your personal information will never result in an administrative decision being made about you.
 
-Note, Employment and Social Development Canada uses GC Forms to collect feedback and mailing list information.
+Note: The Micro-Acquisition pilot at Employment and Social Development Canada uses GC Forms to collect feedback and mailing list information.
 GC Forms is a product developed and managed by the Canadian Digital Service at the Treasury Board of Canada Secretariat.
 The information you provide may be shared with Treasury Board of Canada Secretariat for the purpose of managing GC Forms.
 Learn more about [GC Forms privacy policy](https://digital.canada.ca/legal/privacy/).

--- a/_pages/en/privacy.md
+++ b/_pages/en/privacy.md
@@ -7,23 +7,61 @@ permalink: /en/privacy.html
 
 # Privacy
 
-For the general privacy notice related to this site, see the [privacy notice on Canada.ca](https://www.canada.ca/fr/transparence/confidentialite.html).
-For the privacy notice related to the voluntary survey to suppliers, please see below.
+For the general privacy notice for this website, see below.
+Also see the <a href="{{ site.baseurl }}{% link _pages/en/privacy-contracting.md %}">Privacy Notice Statement for the Micro-Acquisition contracting process</a> and the <a href="{{ site.baseurl }}{% link _pages/en/privacy-survey.md %}">Privacy Notice Statement for the survey to Micro-Acquisition suppliers</a>.
 
-## Privacy Notice Statement for the Micro-acquisition pilot – survey to suppliers
+---
 
-The information you provide is collected under the authority of the [Department of Employment and Social Development Act (DESDA)](https://laws-lois.justice.gc.ca/eng/acts/h-5.7/page-1.html) to evaluate the success of the Micro-Acquisition Pilot.
+The information you provide is collected under the authority of the [Department of Employment and Social Development Act (DESDA)](https://laws-lois.justice.gc.ca/eng/acts/h-5.7/page-1.html) to evaluate the success of the Micro-Acquisition Pilot including but not limited to, assessing demand for this procurement option and achieving the goal of increased participation of developers who would not normally bid on Government of Canada contracts.
 
-Participation in this research initiative for the Micro-Acquisition Pilot is voluntary.
-Refusal to provide personal information will have no consequences.
+Participation in the Micro-Acquisition Pilot is voluntary. Refusal to provide personal information will have no consequences.
 
-The information you provide may be used and/or disclosed for policy analysis, research and/or evaluation purposes.  
+The information you provide by way of feedback, questions, or by requesting to be added to the mailing list, may be used and/or disclosed for policy analysis, research and/or evaluation purposes.
 However, these additional uses and/or disclosures of your personal information will never result in an administrative decision being made about you.
 
-Your personal information is administered in accordance with DESDA, the Privacy Act and other applicable laws.
+Note, Employment and Social Development Canada uses GC Forms to collect feedback and mailing list information.
+GC Forms is a product developed and managed by the Canadian Digital Service at the Treasury Board of Canada Secretariat.
+The information you provide may be shared with Treasury Board of Canada Secretariat for the purpose of managing GC Forms.
+Learn more about [GC Forms privacy policy](https://digital.canada.ca/legal/privacy/).
+
+Your personal information is administered in accordance with the Department of Employment and Social Development Act, the Privacy Act and other applicable laws.
 You have the right to the protection of, access to, and correction of your personal information, which is described in Personal Information Bank [Outreach Activities](https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings/standard-personal-information-banks.html#psu938)(PSU 938).
 Instructions for obtaining this information is outlined in the following government publication entitled [Information about programs and information holdings](https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings.html).
 
 Information about programs and information holdings may also be accessed on-line at any Service Canada Centre.
+
+## Third-Party Social Media
+
+The Government of Canada's use of social media serves as an extension of its presence on the Web.
+Social media account(s) are public and are not hosted on Government of Canada servers.
+Users who choose to interact with the Government of Canada, including the Micro-Acquisition pilot, via social media should read the terms of service and privacy policies of these third-party service providers and those of any applications used to access them.
+
+## Web Analytics
+
+Web analytics is the collection, analysis, measurement, and reporting of data about Web traffic and visits for purposes of understanding and optimizing Web usage.
+Information in digital markers may be used in conjunction with computer request data to identify and track your online interactions with the Micro-Acquisition Pilot website.
+
+The Micro-Acquisition Pilot team uses Google Analytics and log file analysis to improve the Micro-Acquisition Pilot website.
+When your computer requests a Web page, the following types of information are collected and used for Web analytics:
+
+- the originating IP address
+- the date and time of the request
+- the type of browser used
+- the page(s) visited
+- referral website
+
+Google analytics data will not be used to collect additional personal information beyond what is provided by Google Analytics.
+
+If you wish, you may opt out of being tracked by Google Analytics by disabling or refusing the cookies; by disabling JavaScript within your browser; or by using the [Google Analytics Opt-Out Browser Add-On](https://tools.google.com/dlpage/gaoptout?hl=en).
+Disabling Google Analytics or JavaScript will still permit you to access comparable information or services from our websites.
+However, if you disable your session cookie option, you will still be able to access our public website, but you might have difficulties accessing any secure services.
+
+Data collected for Web analytics purposes goes outside of Canada to Google servers and may be processed in any country where Google operates servers.
+Data may be subject to the governing legislation of that country, [for example the USA Patriot Act].
+For further information about Google Analytics, please refer to the [Google Analytics terms of service](https://www.google.com/policies/privacy/partners/).
+
+Information used for the purpose of Web analytics is collected pursuant to section 7 of the *Financial Administration Act*.
+Such data may be used for communications and information technology statistical purposes, audit, and evaluation, research, planning and reporting.
+For more information on how your privacy is safeguarded in relation to web analytics, see the Treasury Board Secretariat *Standard on Privacy and Web Analytics*.
 
 You have the right to file a complaint with the Privacy Commissioner of Canada regarding the institution’s handling of your personal information at: [https://www.priv.gc.ca/faqs/index_e.asp#q005](https://www.priv.gc.ca/faqs/index_e.asp#q005).

--- a/_pages/fr/confidentialite-contractuel.md
+++ b/_pages/fr/confidentialite-contractuel.md
@@ -14,7 +14,7 @@ Si vous refusez de fournir les informations personnelles requises dans le cadre 
 
 Remarque : Le pilote de micro-acquisition de Emploi et Développement social Canada (EDSC) utilise les Formulaires GC pour recueillir les informations relatives aux demandes.
 Les Formulaires GC sont un produit développé et géré par le Service numérique canadien du Secrétariat du Conseil du Trésor du Canada.
-Apprenez-en plus sur la [politique de confidentialité des formulaires GC](https://digital.canada.ca/legal/privacy/).
+Apprenez-en plus sur la [politique de confidentialité des formulaires GC](https://numerique.canada.ca/transparence/confidentialite/).
 
 Vos renseignements personnels pourraient être utilisés et communiqués aux fins d’analyse stratégique, de recherche et d’évaluation.
 Cependant, de telles utilisations ou divulgations additionnelles de vos renseignements ne serviront jamais à prendre une décision administrative à votre sujet.

--- a/_pages/fr/confidentialite-contractuel.md
+++ b/_pages/fr/confidentialite-contractuel.md
@@ -1,0 +1,29 @@
+---
+layout: default
+ref: contracting
+lang: fr
+permalink: /fr/confidentialite-contractuel.html
+---
+
+# Déclaration de confidentialité pour le processus contractuel du pilote de Micro-Acquisition
+
+Les renseignements que vous fournissez sont recueillis en vertu de la [Loi sur la gestion des finances publiques (LGFP)](https://laws-lois.justice.gc.ca/fra/lois/f-11/) pour évaluer vos compétences dans le cadre du processus de sélection des candidatures et pour effectuer le paiement des fournisseurs choisis pour travailler sur les opportunités de micro-acquisition.
+
+La participation au pilote de micro-acquisition (y compris le fait de postuler à des opportunités, de compléter et de soumettre des travaux pour des opportunités de micro-acquisition, et d'accepter un paiement) est volontaire.
+Si vous refusez de fournir les informations personnelles requises dans le cadre de l'évaluation des candidatures, vous ne pourrez pas participer aux opportunités.
+
+Remarque : Le Emploi et Développement social Canada (EDSC) utilise les Formulaires GC pour recueillir les informations relatives aux demandes.
+Les Formulaires GC sont un produit développé et géré par le Service numérique canadien du Secrétariat du Conseil du Trésor du Canada.
+Pour en savoir plus sur la [politique de confidentialité des formulaires GC](https://digital.canada.ca/legal/privacy/).
+
+Vos renseignements personnels pourraient être utilisés et communiqués aux fins d’analyse stratégique, de recherche et d’évaluation.
+Cependant, de telles utilisations ou divulgations additionnelles de vos renseignements ne serviront jamais à prendre une décision administrative à votre sujet.
+
+Le nom du fournisseur gagnant pour chaque opportunité de micro-acquisition peut être publié dans le cadre du processus de passation de marché.
+
+Les renseignements personnels qui vous concernent sont administrés conformément à la *Loi sur la gestion des finances publiques*, la *loi sur le ministère de l’Emploi et du Développement social*, la *Loi sur la protection des renseignements personnels* et d’autres lois applicables. Vous avez droit à la protection, à la correction de vos renseignements personnels et à l’accès à ceux-ci; ce droit est décrit dans le répertoire de données personnelles [Marchés de services professionnels](https://www.canada.ca/fr/secretariat-conseil-tresor/services/acces-information-protection-reseignements-personnels/acces-information/renseignements-programmes-fonds-renseignements/fichiers-renseignements-personnels-ordinaires.html#pou912) (POU 912).
+Les directives pour obtenir ces renseignements sont décrites dans la publication du gouvernement intitulée [Renseignement sur les programmes et les fond de renseignements](https://www.canada.ca/fr/emploi-developpement-social/ministere/transparence/aai/rapports/infosource.html).
+
+Vous pouvez également accéder à Renseignement sur les programmes et les fond de renseignements dans n’importe quel Centre Service Canada.
+
+Vous avez le droit de déposer une plainte auprès du Commissiare à la protection de la vie privée concernant le traitement de vos renseignements personnels par le Ministère [https://www.priv.gc.ca/faqs/index_f.asp#q005](https://www.priv.gc.ca/faqs/index_f.asp#q005).

--- a/_pages/fr/confidentialite-contractuel.md
+++ b/_pages/fr/confidentialite-contractuel.md
@@ -12,9 +12,9 @@ Les renseignements que vous fournissez sont recueillis en vertu de la [Loi sur l
 La participation au pilote de micro-acquisition (y compris le fait de postuler à des opportunités, de compléter et de soumettre des travaux pour des opportunités de micro-acquisition, et d'accepter un paiement) est volontaire.
 Si vous refusez de fournir les informations personnelles requises dans le cadre de l'évaluation des candidatures, vous ne pourrez pas participer aux opportunités.
 
-Remarque : Le Emploi et Développement social Canada (EDSC) utilise les Formulaires GC pour recueillir les informations relatives aux demandes.
+Remarque : Le pilote de micro-acquisition de Emploi et Développement social Canada (EDSC) utilise les Formulaires GC pour recueillir les informations relatives aux demandes.
 Les Formulaires GC sont un produit développé et géré par le Service numérique canadien du Secrétariat du Conseil du Trésor du Canada.
-Pour en savoir plus sur la [politique de confidentialité des formulaires GC](https://digital.canada.ca/legal/privacy/).
+Apprenez-en plus sur la [politique de confidentialité des formulaires GC](https://digital.canada.ca/legal/privacy/).
 
 Vos renseignements personnels pourraient être utilisés et communiqués aux fins d’analyse stratégique, de recherche et d’évaluation.
 Cependant, de telles utilisations ou divulgations additionnelles de vos renseignements ne serviront jamais à prendre une décision administrative à votre sujet.

--- a/_pages/fr/confidentialite-sondage.md
+++ b/_pages/fr/confidentialite-sondage.md
@@ -8,7 +8,7 @@ permalink: /fr/confidentialite-sondage.html
 
 Les renseignements que vous fournissez sont recueillis en vertu de la [Loi sur le ministère de l’Emploi et du Développement social (LMEDS)](https://laws-lois.justice.gc.ca/fra/lois/h-5.7/page-1.html) pour évaluer le succès du projet pilote de micro-acquisition y compris, mais sans s'y limiter, l'évaluation de la demande pour cette option d'approvisionnement et l'atteinte de l'objectif d'une participation accrue des fournisseurs qui ne soumissionneraient pas normalement aux contrats du gouvernement du Canada.
 
-La participation à cet sondage pour les fournisseurs de micro-acquisition est volontaire.
+La participation à ce sondage pour les fournisseurs de micro-acquisition est volontaire.
 Le refus de fournir des renseignements personnels n'aura aucune conséquence.
 
 Les informations que vous fournissez par le biais de commentaires, de questions ou en demandant à être ajouté à la liste de diffusion, pourraient être utilisés et communiqués aux fins d’analyse stratégique, de recherche et d’évaluation.

--- a/_pages/fr/confidentialite-sondage.md
+++ b/_pages/fr/confidentialite-sondage.md
@@ -1,0 +1,23 @@
+---
+layout: default
+ref: survey
+lang: fr
+permalink: /fr/confidentialite-sondage.html
+---
+# Déclaration de confidentialité pour le sondage auprès des fournisseurs de micro-acquisition
+
+Les renseignements que vous fournissez sont recueillis en vertu de la [Loi sur le ministère de l’Emploi et du Développement social (LMEDS)](https://laws-lois.justice.gc.ca/fra/lois/h-5.7/page-1.html) pour évaluer le succès du projet pilote de micro-acquisition y compris, mais sans s'y limiter, l'évaluation de la demande pour cette option d'approvisionnement et l'atteinte de l'objectif d'une participation accrue des fournisseurs qui ne soumissionneraient pas normalement aux contrats du gouvernement du Canada.
+
+La participation à cet sondage pour les fournisseurs de micro-acquisition est volontaire.
+Le refus de fournir des renseignements personnels n'aura aucune conséquence.
+
+Les informations que vous fournissez par le biais de commentaires, de questions ou en demandant à être ajouté à la liste de diffusion, pourraient être utilisés et communiqués aux fins d’analyse stratégique, de recherche et d’évaluation.
+Cependant, de telles utilisations ou divulgations additionnelles de vos renseignements ne serviront jamais à prendre une décision administrative à votre sujet.
+
+Les renseignements personnels qui vous concernent sont administrés conformément à la LMEDS, la Loi sur la protection des renseignements personnels et d’autres lois applicables.
+Vous avez droit à la protection, à la correction de vos renseignements personnels et à l’accès à ceux-ci; ce droit est décrit dans le répertoire de données personnelles [Activités de sensibilisation](https://www.canada.ca/fr/secretariat-conseil-tresor/services/acces-information-protection-reseignements-personnels/acces-information/renseignements-programmes-fonds-renseignements/fichiers-renseignements-personnels-ordinaires.html#pou938) (POU 938).
+Les directives pour obtenir ces renseignements sont décrites dans la publication du gouvernement intitulée [Renseignement sur les programmes et les fond de renseignements](https://www.canada.ca/fr/emploi-developpement-social/ministere/transparence/aai/rapports/infosource.html).
+
+Vous pouvez également accéder aux renseignements sur les programmes et les fond de renseignements dans n’importe quel bureau de Service Canada.
+
+Vous avez le droit de déposer une plainte auprès du Commissiare à la protection de la vie privée concernant le traitement de vos renseignements personnels par le Ministère [https://www.priv.gc.ca/faqs/index_f.asp#q005](https://www.priv.gc.ca/faqs/index_f.asp#q005).

--- a/_pages/fr/confidentialite.md
+++ b/_pages/fr/confidentialite.md
@@ -22,7 +22,7 @@ Cependant, de telles utilisations ou divulgations additionnelles de vos renseign
 
 Remarque : Le pilote de micro-acquisition de Emploi et Développement social Canada (EDSC) utilise les Formulaires GC pour recueillir les informations relatives aux demandes.
 Les Formulaires GC sont un produit développé et géré par le Service numérique canadien du Secrétariat du Conseil du Trésor du Canada.
-Apprenez-en plus sur la [la politique de confidentialité des Formulaires GC](https://digital.canada.ca/legal/privacy/).
+Apprenez-en plus sur la [la politique de confidentialité des Formulaires GC](https://numerique.canada.ca/transparence/confidentialite/).
 
 Les renseignements personnels qui vous concernent sont administrés conformément à la *Loi sur le ministère de l’Emploi et du Développement social*, la *Loi sur la protection des renseignements personnels* et d’autres lois applicables.
 Vous avez droit à la protection, à la correction de vos renseignements personnels et à l’accès à ceux-ci; ce droit est décrit dans le répertoire de données personnelles [Activités de sensibilisation](https://www.canada.ca/fr/secretariat-conseil-tresor/services/acces-information-protection-reseignements-personnels/acces-information/renseignements-programmes-fonds-renseignements/fichiers-renseignements-personnels-ordinaires.html#pou938) (POU 938).

--- a/_pages/fr/confidentialite.md
+++ b/_pages/fr/confidentialite.md
@@ -20,8 +20,9 @@ Le refus de fournir des renseignements personnels n'aura aucune conséquence.
 Les informations que vous fournissez par le biais de commentaires, de questions ou en demandant à être ajouté à la liste de diffusion, pourraient être utilisés et communiqués aux fins d’analyse stratégique, de recherche et d’évaluation.
 Cependant, de telles utilisations ou divulgations additionnelles de vos renseignements ne serviront jamais à prendre une décision administrative à votre sujet.
 
-Remarque : Le Emploi et Développement social Canada (EDSC) utilise les Formulaires GC pour recueillir les informations relatives aux demandes.
-Les Formulaires GC sont un produit développé et géré par le Service numérique canadien du Secrétariat du Conseil du Trésor du Canada. Pour en savoir plus sur [la politique de confidentialité des Formulaires GC](https://digital.canada.ca/legal/privacy/).
+Remarque : Le pilote de micro-acquisition de Emploi et Développement social Canada (EDSC) utilise les Formulaires GC pour recueillir les informations relatives aux demandes.
+Les Formulaires GC sont un produit développé et géré par le Service numérique canadien du Secrétariat du Conseil du Trésor du Canada.
+Apprenez-en plus sur la [la politique de confidentialité des Formulaires GC](https://digital.canada.ca/legal/privacy/).
 
 Les renseignements personnels qui vous concernent sont administrés conformément à la *Loi sur le ministère de l’Emploi et du Développement social*, la *Loi sur la protection des renseignements personnels* et d’autres lois applicables.
 Vous avez droit à la protection, à la correction de vos renseignements personnels et à l’accès à ceux-ci; ce droit est décrit dans le répertoire de données personnelles [Activités de sensibilisation](https://www.canada.ca/fr/secretariat-conseil-tresor/services/acces-information-protection-reseignements-personnels/acces-information/renseignements-programmes-fonds-renseignements/fichiers-renseignements-personnels-ordinaires.html#pou938) (POU 938).

--- a/_pages/fr/confidentialite.md
+++ b/_pages/fr/confidentialite.md
@@ -2,28 +2,65 @@
 layout: default
 ref: privacy
 lang: fr
-permalink: /fr/privacy.html
+permalink: /fr/confidentialite.html
 ---
 
 # Confidentialité
 
-Pour la déclaration de confidentialité général relative à ce site, voir [la déclaration  de confidentialité sur Canada.ca](https://www.canada.ca/fr/transparence/confidentialite.html).
-Pour la déclaration de confidentialité relative au sondage volontaire auprès des fournisseurs, voir ci-dessous.
+Pour la déclaration de confidentialité général relative à ce site, voir voir ci-dessous.
+Voir également la <a href="{{ site.baseurl }}{% link _pages/fr/confidentialite-contractuel.md %}">déclaration de confidentialité pour le processus contractuel de micro-acquisition</a> et la <a href="{{ site.baseurl }}{% link _pages/fr/confidentialite-sondage.md %}">déclaration de confidentialité pour le sondage volontaire auprès des fournisseurs</a>.
 
-## La déclaration de confidentialité du pilote de micro-acquisition – sondage auprès des fournisseurs
+---
 
-Les renseignements que vous fournissez sont recueillis en vertu de la [Loi sur le ministère de l’Emploi et du Développement social (LMEDS)](https://laws-lois.justice.gc.ca/fra/lois/h-5.7/page-1.html) pour évaluer le succès du projet pilote de micro-acquisition.
+Les renseignements que vous fournissez sont recueillis en vertu de la [Loi sur le ministère de l’Emploi et du Développement social (LMEDS)](https://laws-lois.justice.gc.ca/fra/lois/h-5.7/page-1.html) pour évaluer le succès du projet pilote de micro-acquisition y compris, mais sans s'y limiter, l'évaluation de la demande pour cette option d'approvisionnement et l'atteinte de l'objectif d'une participation accrue des fournisseurs qui ne soumissionneraient pas normalement aux contrats du gouvernement du Canada.
 
-La participation à cette initiative de recherche pour le projet pilote de micro-acquisition est volontaire.
+La participation au projet pilote de micro-acquisition est volontaire.
 Le refus de fournir des renseignements personnels n'aura aucune conséquence.
 
-Vos renseignements personnels pourraient être utilisés et communiqués aux fins d’analyse stratégique, de recherche et d’évaluation.
+Les informations que vous fournissez par le biais de commentaires, de questions ou en demandant à être ajouté à la liste de diffusion, pourraient être utilisés et communiqués aux fins d’analyse stratégique, de recherche et d’évaluation.
 Cependant, de telles utilisations ou divulgations additionnelles de vos renseignements ne serviront jamais à prendre une décision administrative à votre sujet.
 
-Les renseignements personnels qui vous concernent sont administrés conformément à la LMEDS, la Loi sur la protection des renseignements personnels et d’autres lois applicables.
+Remarque : Le Emploi et Développement social Canada (EDSC) utilise les Formulaires GC pour recueillir les informations relatives aux demandes.
+Les Formulaires GC sont un produit développé et géré par le Service numérique canadien du Secrétariat du Conseil du Trésor du Canada. Pour en savoir plus sur [la politique de confidentialité des Formulaires GC](https://digital.canada.ca/legal/privacy/).
+
+Les renseignements personnels qui vous concernent sont administrés conformément à la *Loi sur le ministère de l’Emploi et du Développement social*, la *Loi sur la protection des renseignements personnels* et d’autres lois applicables.
 Vous avez droit à la protection, à la correction de vos renseignements personnels et à l’accès à ceux-ci; ce droit est décrit dans le répertoire de données personnelles [Activités de sensibilisation](https://www.canada.ca/fr/secretariat-conseil-tresor/services/acces-information-protection-reseignements-personnels/acces-information/renseignements-programmes-fonds-renseignements/fichiers-renseignements-personnels-ordinaires.html#pou938) (POU 938).
 Les directives pour obtenir ces renseignements sont décrites dans la publication du gouvernement intitulée [Renseignement sur les programmes et les fond de renseignements](https://www.canada.ca/fr/emploi-developpement-social/ministere/transparence/aai/rapports/infosource.html).
 
 Vous pouvez également accéder aux renseignements sur les programmes et les fond de renseignements dans n’importe quel bureau de Service Canada.
+
+## Médias sociaux de tiers
+
+L'utilisation des médias sociaux par le gouvernement du Canada constitue le prolongement de sa présence sur le Web.
+Les comptes des médias sociaux sont publics et ne sont pas hébergés sur les serveurs du gouvernement du Canada.
+Les utilisateurs qui choisissent d'interagir avec le gouvernement du Canada, notamment le Service numérique canadien, par le truchement des médias sociaux devraient lire les conditions de service et les politiques de confidentialité de ces tiers fournisseurs de services et celles liées aux applications utilisées pour y accéder.
+
+## Web analytique
+
+Par Web analytique, on entend la collecte, l'analyse, la mesure et la présentation de données sur le trafic d'un site Internet et sur les visites effectuées dans le but de comprendre et d'optimiser l'utilisation du Web.
+Les données des marqueurs numériques peuvent être utilisées de concert avec les demandes de données informatiques pour déterminer et repérer vos interactions en ligne avec le site Web du pilote de micro-acquisition.
+
+L'équipe du pilote de micro-acquisition utilise Google Analytics et l'analyse des fichiers journaux pour améliorer le site Web du du pilote de micro-acquisition.
+Lorsque votre ordinateur demande une page Web, les types de données suivants sont recueillis et utilisés pour le Web analytique :
+
+- l'adresse IP d'origine;
+- la date et l'heure de la demande;
+- le type de navigateur utilisé;
+- la page visitée ou les pages visitées;
+- le site Web de référencement.
+
+Les données de Google Analytics ne seront pas utilisées pour collecter des informations personnelles supplémentaires au-delà de celles fournies par Google Analytics.
+
+Si vous le souhaitez, vous pouvez choisir de ne pas être surveillé par Google Analytics en désactivant ou en refusant les témoins, en désactivant JavaScript dans votre navigateur ou en utilisant le [Module complémentaire de navigateur pour la désactivation de Google Analytics (disponible en anglais uniquement)](https://tools.google.com/dlpage/gaoptout?hl=fr).
+Même si vous désactivez Google Analytics ou JavaScript, vous pourrez encore accéder à des données et à des services comparables de nos sites Web.
+Par contre, si vous désactivez votre option de témoin volatil, vous aurez peut-être de la difficulté à accéder à des sites sécurisés, mais pourrez encore consulter notre site Web public.
+
+Les données recueillies pour le Web analytique sont transmises à l'extérieur du Canada vers des serveurs de Google et peuvent être traitées dans n'importe quel pays où Google exploite des serveurs.
+Les données peuvent être assujetties à la législation applicable de ce pays (par exemple la USA Patriot Act).
+Pour un complément d'information sur Google Analytics, veuillez-vous référer aux [Conditions de service de Google Analytics](https://www.google.com/intl/fr/policies/privacy/partners/).
+
+Les données utilisées aux fins de Web analytique sont recueillies conformément à l'article 7 de la Loi sur la gestion des finances publiques.
+Ces données peuvent être utilisées à des fins de statistiques sur les technologies des communications et de l'information, de vérification, d'évaluation, de recherche, de planification et de production de rapports.
+Pour un complément d'information sur la façon dont vos renseignements personnels sont protégés dans le cadre du Web analytique, reportez-vous à la Norme sur la protection de la vie privée et le Web analytique.
 
 Vous avez le droit de déposer une plainte auprès du Commissiare à la protection de la vie privée concernant le traitement de vos renseignements personnels par le Ministère [https://www.priv.gc.ca/faqs/index_f.asp#q005](https://www.priv.gc.ca/faqs/index_f.asp#q005).


### PR DESCRIPTION
This PR includes an updated privacy notice for the supplier survey as well as a new privacy notice for the website and the contracting process.
Note the PNS for the survey and the website are very similar and have a lot of similar text.
These PNS have been approved by the privacy team.

Breadcrumbs have been added to the survey and contracting PNS as they link from the main privacy page.
