### PR TITLE
chore: Copy Markdownlint setup from ORE

### DIFF
--- a/.github/workflows/markdownlint-problem-matcher.json
+++ b/.github/workflows/markdownlint-problem-matcher.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "markdownlint",
+            "pattern": [
+                {
+                    "regexp": "^([^:]*):(\\d+):?(\\d+)?\\s([\\w-\\/]*)\\s(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "code": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,41 @@
+name: Markdownlint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/markdownlint-problem-matcher.json"
+      - ".github/workflows/markdownlint.yml"
+      - ".markdownlint.json"
+      - "package*.json"
+      - "**/*.md"
+
+  push:
+    branches-ignore:
+      - "dependabot/**"
+    paths:
+      - ".github/workflows/markdownlint-problem-matcher.json"
+      - ".github/workflows/markdownlint.yml"
+      - ".markdownlint.json"
+      - "package*.json"
+      - "**/*.md"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: "npm"
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Run Markdownlint
+        run: |
+          echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
+          npm run lint-markdown

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "([Français](#prototype-site-web-micro-acquisition))",
   "main": "index.js",
   "scripts": {
-    "lint-markdown": "markdownlint -i node_modules -i _site -i _includes -i README.md -i SECURITY.md \"**/*.md\"",
+    "lint-markdown": "markdownlint -i node_modules -i _site \"**/*.md\"",
     "lint-editorconfig": "editorconfig-checker -disable-indentation -disable-insert-final-newline",
     "open-licences": "licensee --errors-only",
     "test": "npm run lint-markdown && npm run lint-editorconfig && npm run open-licences"


### PR DESCRIPTION
This will temporarily duplicate the other CI, then only trigger on Markdown files going forward