### PR TITLE
Fixed alt tag for the logo

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -33,8 +33,8 @@
     <div class="row">
       <div class="brand col-xs-8 col-sm-9 col-md-6">
         <a href="{{ site.data.i18n.general.nav.Canada.link[page.lang] }}">
-          <img src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/assets/sig-blk-{{ page.lang }}.svg" alt="{{ site.data.i18n.general.nav.Canada.en }}" property="logo">
-          <span class="wb-inv"> / <span lang="fr">{{ site.data.i18n.general.nav.Canada.fr }}</span></span>
+          <img src="{{ site.wet_cdts_hosturl }}/{{ site.wet_cdts_version }}/assets/sig-blk-{{ page.lang }}.svg" alt="Gouvernement du Canada" property="logo">
+          <span class="wb-inv"> / <span lang="en">Government of Canada</span></span>
         </a>
       </div>
     </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]--><!--[if gt IE 8]><!-->
+<!DOCTYPE html><!--[if lt IE 9]><html class="no-js lt-ie9" lang="fr" dir="ltr"><![endif]--><!--[if gt IE 8]><!-->
 <html class="no-js" lang="{{ page.lang }}" dir="ltr">
 <!--<![endif]-->
 {% include head.html %}


### PR DESCRIPTION
Fixed this issue from the report:

The alt text for the "Government of Canada" logo on the French pages is in English. Text needs to be updated to French "Gouvernement du Canada" or a lang="en" has to be added to that section. Source code:< a href="https://www.canada.ca/fr.html"> <img src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_39/assets/sig-blk-fr.svg" alt="Government of Canada" property="logo"> <span class="wb-inv"> / <span lang="fr">Gouvernement du Canada</span></span> </a> Visit the following page to see an example code: https://www.canada.ca/fr.html The French text is placed in the alt attribute and the English text is in the span with a lang="en" attribute. Note: on the French pages, there is no need to add lang="fr" to any element. The document language was already identified in the <html> element. Only sections that has different language than the documents' must be identified.



link : http://esdc.prv/cgi-bin/scdtic-ictdcs/assessment.aspx?id=393