### PR TITLE
Update the blue bar

### DIFF
--- a/_data/i18n/general.yml
+++ b/_data/i18n/general.yml
@@ -199,17 +199,16 @@ apply:
   rejection:
     en: Canada may reject your application due to poor performance on a previous contract with Canada.
     fr: Le Canada peut rejeter votre demande en raison d'une mauvaise exécution d'un contrat antérieur avec le Canada.
-
 alert:
   alert1:
     en: This website is part of a pilot. If you have suggestions for improvements, we'd love to hear them! Please fill in a
-    fr: Ce site fait partie d'un pilote. Si vous avez des suggestions d'améliorations, nous serions ravis de les entendre. Veuillez remplir un
+    fr: Ce site fait partie d'un pilote. Si vous avez des suggestions d'améliorations, nous serions ravis de les entendre! Veuillez remplir un
   issue:
     en: or if you prefer, create an
-    fr: ou si vous préférez, créez une
+    fr: ou si vous préférez, créez un
   alert2:
     en: issue
-    fr: question (site en anglais seulement)
+    fr: <i>issue</i> (point)
   GCForm:
       en:
         link: https://forms-formulaires.alpha.canada.ca/id/35
@@ -218,5 +217,5 @@ alert:
         link: https://forms-formulaires.alpha.canada.ca/fr/id/35
         title: formulaire de commentaires
   repository:
-      en: on our open repository
-      fr: sur notre dépôt ouvert
+      en: in our open repository (GitHub account needed)
+      fr: dans notre dépôt ouvert (compte GitHub requis – interface en anglais seulement)

--- a/_data/i18n/general.yml
+++ b/_data/i18n/general.yml
@@ -199,14 +199,14 @@ apply:
 
 alert:
   alert1:
-    en: This website is part of a pilot. If you want to share your feedback, please open an 
-    fr: Ce site fait partie d'un pilote. Si vous souhaitez partager vos commentaires, poser une 
+    en: This website is part of a pilot. If you have suggestions for improvements, we'd love to hear them! Please fill in a
+    fr: Ce site fait partie d'un pilote. Si vous avez des suggestions d'améliorations, nous serions ravis de les entendre. Veuillez remplir un
   issue:
-    en: issue
-    fr: question
+    en: or if you prefer, create an
+    fr: ou si vous préférez, créez une
   alert2:
-    en: or fill in a
-    fr: ou remplir un
+    en: issue
+    fr: question (site en anglais seulement)
   GCForm:
       en:
         link: https://forms-formulaires.alpha.canada.ca/id/35
@@ -214,3 +214,6 @@ alert:
       fr:
         link: https://forms-formulaires.alpha.canada.ca/fr/id/35
         title: formulaire de commentaires
+  repository:
+      en: on our open repository
+      fr: sur notre dépôt ouvert

--- a/_includes/pre-footer.html
+++ b/_includes/pre-footer.html
@@ -2,11 +2,9 @@
   <div class="pageDetails">
     <div class="row">
       <div class="alert alert-info" style="font-size:17px;">
-        <!-- <p> This website is part of a pilot. If you want to share your feedback, please open an  <a href="https://github.com/canada-ca/micro-acquisition/issues">issue</a> or send us an <a href="mailto:microacquisition@hrsdc-rhdcc.gc.ca">email</a>.</p> -->
-        <!-- <p>This website is part of a pilot and not live yet. We are currently working to make it available soon. Until then if you see anything that isn’t working or want to share your feedback, please open an  <a href="https://github.com/canada-ca/micro-acquisition/issues">issue</a> or send us an <a href="mailto:microacquisition@hrsdc-rhdcc.gc.ca">email</a>.</p> -->
         <p>
-          {{ site.data.i18n.general.alert.alert1[page.lang] }}&nbsp;<a href="https://github.com/canada-ca/micro-acquisition/issues">{{ site.data.i18n.general.alert.issue[page.lang] }}</a>
-          {{ site.data.i18n.general.alert.alert2[page.lang] }}&nbsp;<a href="{{ site.data.i18n.general.alert.GCForm.[page.lang].link }}">{{ site.data.i18n.general.alert.GCForm.[page.lang].title }}</a>.
+          {{ site.data.i18n.general.alert.alert1[page.lang] }}&nbsp;<a href="{{ site.data.i18n.general.alert.GCForm.[page.lang].link }}">{{ site.data.i18n.general.alert.GCForm.[page.lang].title }}</a>
+          {{ site.data.i18n.general.alert.issue[page.lang] }}&nbsp;<a href="https://github.com/canada-ca/micro-acquisition/issues">{{ site.data.i18n.general.alert.alert2[page.lang]}}</a> {{ site.data.i18n.general.alert.repository[page.lang]}}.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Spent a lot of time thinking about this and in the end kept the link to the issues in the blue bar (rather than ask CDS to add it to the GC Form). I just really like the visibility of it - promoting that we encourage working in the open on repos.

Interested in your thoughts!