### PR TITLE
Update references to the application form

### DIFF
--- a/_data/i18n/general.yml
+++ b/_data/i18n/general.yml
@@ -185,8 +185,8 @@ apply:
     en: "To apply to this opportunity, fill in an"
     fr: "Pour présenter votre demande pour cette opportunité, remplissez un"
   application:
-    en: application form (PDF 61 kB, opens a new window)
-    fr: formulaire de demande (PDF 66 kB, ouvre une nouvelle fenêtre)
+    en: application form
+    fr: formulaire de demande
   description2:
     en: "and send it to:"
     fr: "et envoyez le à:"

--- a/_includes/howtoapply.html
+++ b/_includes/howtoapply.html
@@ -4,6 +4,6 @@
        <h2>{{ site.data.i18n.general.apply.title[page.lang] }}</h2>
        <p>{{ site.data.i18n.general.apply.checklist[page.lang] }}&nbsp;<a href="{{ site.baseurl }}{%- if page.lang == 'fr' -%}{% link _pages/fr/guide-utilisateur.md %}{%- else -%}{% link _pages/en/user-guide.md %}{%- endif -%}">{{ site.data.i18n.general.apply.guide[page.lang] }}.</a></p>
        <p>{{ site.data.i18n.general.apply.rejection[page.lang] }}</p>
-       <p>{{ site.data.i18n.general.apply.description1[page.lang] }}&nbsp;<a href="{{ site.baseurl }}{%- if page.lang == 'fr' -%}{% link assets/formulaire-de-demande.pdf %}{%- else -%}{% link assets/application-form.pdf %}{%- endif -%}" target="_blank">{{ site.data.i18n.general.apply.application[page.lang] }}</a> {{ site.data.i18n.general.apply.description2[page.lang] }}&nbsp;<a href="mailto:microacquisition@hrsdc-rhdcc.gc.ca">microacquisition@hrsdc-rhdcc.gc.ca</a></p>
+       <p>{{ site.data.i18n.general.apply.description1[page.lang] }}&nbsp;<a href="{{ site.baseurl }}{%- if page.lang == 'fr' -%}{% link assets/formulaire-de-demande.pdf %}{%- else -%}{% link assets/application-form.pdf %}{%- endif -%}" target="_blank">{{ site.data.i18n.general.apply.application[page.lang] }}</a></p>
     </div>
 </div>

--- a/_pages/en/user-guide.md
+++ b/_pages/en/user-guide.md
@@ -58,8 +58,9 @@ They have a network of offices across Canada.
 
 To apply to an opportunity:
 
-1. open and fill out an <a href="{{ site.baseurl }}{% link assets/application-form.pdf %}" target="_blank">application form (PDF 61 kB, opens a new window)</a>
-2. send it to [microacquisition@hrsdc-rhdcc.gc.ca](mailto:microacquisition@hrsdc-rhdcc.gc.ca).
+1. Click on the 'application form' link in the footer for the open opportunity you want to apply to
+2. Fill in the form
+3. Click submit
 
 Your application will be evaluated based on criteria that are marked as a pass or fail (there is no scoring).
 

--- a/_pages/en/user-guide.md
+++ b/_pages/en/user-guide.md
@@ -60,7 +60,7 @@ To apply to an opportunity:
 
 1. Click on the 'application form' link in the footer for the open opportunity you want to apply to
 2. Fill in the form
-3. Click submit
+3. Click 'Submit'
 
 Your application will be evaluated based on criteria that are marked as a pass or fail (there is no scoring).
 

--- a/_pages/fr/guide-utilisateur.md
+++ b/_pages/fr/guide-utilisateur.md
@@ -58,7 +58,7 @@ Ils ont un réseau de bureaux partout au Canada.
 
 Pour présenter une demande pour une opportunité:
 
-1. Cliquez sur le lien "formulaire de demande" dans le pied de page de l'opportunité ouverte à laquelle vous souhaitez postuler.
+1. Cliquez sur le lien "formulaire de demande" dans le pied de page de l'opportunité ouverte à laquelle vous souhaitez postuler
 2. Remplissez le formulaire
 3. Cliquez sur "Soumettre"
 

--- a/_pages/fr/guide-utilisateur.md
+++ b/_pages/fr/guide-utilisateur.md
@@ -58,8 +58,9 @@ Ils ont un réseau de bureaux partout au Canada.
 
 Pour présenter une demande pour une opportunité:
 
-1. ouvrez et remplissez un <a href="{{ site.baseurl }}{% link assets/formulaire-de-demande.pdf %}" target="_blank"> formulaire de demande (PDF 66 kb, ouvre une nouvelle fenêtre)</a>
-2. retournez le formulaire rempli à [microacquisition@hrsdc-rhdcc.gc.ca](mailto:microacquisition@hrsdc-rhdcc.gc.ca).
+1. Cliquez sur le lien "formulaire de demande" dans le pied de page de l'opportunité ouverte à laquelle vous souhaitez postuler.
+2. Remplissez le formulaire
+3. Cliquez sur "Soumettre"
 
 Votre candidature sera évaluée sur la base de critères qui sont notés comme une réussite ou un échec (il n'y a pas de notation).
 


### PR DESCRIPTION
In the user guide instructions for 'how to apply' the link to the pdf application form has been removed and the instructions modified slightly (click on 'submit' rather than, send your form in an email to...)

The footer (and data in the .yml file) has been updated with one update remaining - once the next opportunity is live and the application form is ready, the link to the live form needs to be added to the .yml file.

In the event that we have more than one opportunity open at once we will need to create a second footer (as the application form is different for each opportunity).